### PR TITLE
chore: suppress unit test warnings

### DIFF
--- a/apps/nuxt-regle/layers/base/app/components/ui/dialog/__tests__/Dialog.test.ts
+++ b/apps/nuxt-regle/layers/base/app/components/ui/dialog/__tests__/Dialog.test.ts
@@ -9,6 +9,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogFooter,
 } from '../index'
 import { useDisclosure } from "~base/app/composables/useDisclosure"
@@ -50,7 +51,10 @@ const TestDialog = defineComponent({
               {
                 default: () => [
                   h(DialogHeader, {}, {
-                    default: () => h(DialogTitle, {}, { default: () => titleText }),
+                    default: () => [
+                      h(DialogTitle, {}, { default: () => titleText }),
+                      h(DialogDescription, { class: 'sr-only' }, { default: () => 'Dialog description' }),
+                    ],
                   }),
                   h(DialogFooter, {}, {
                     default: () => [

--- a/apps/nuxt-regle/layers/base/app/components/ui/drawer/__tests__/Drawer.test.ts
+++ b/apps/nuxt-regle/layers/base/app/components/ui/drawer/__tests__/Drawer.test.ts
@@ -9,6 +9,7 @@ import {
   DrawerContent,
   DrawerHeader,
   DrawerTitle,
+  DrawerDescription,
   DrawerFooter,
 } from '../index'
 import { useDisclosure } from "~base/app/composables/useDisclosure"
@@ -53,7 +54,10 @@ const TestDrawer = defineComponent({
                 default: () => [
                   h('div', { class: 'flex flex-col' }, [
                     h(DrawerHeader, {}, {
-                      default: () => h(DrawerTitle, {}, { default: () => titleText }),
+                      default: () => [
+                        h(DrawerTitle, {}, { default: () => titleText }),
+                        h(DrawerDescription, { class: 'sr-only' }, { default: () => 'Drawer description' }),
+                      ],
                     }),
                     h('div', {}, drawerContentText),
                   ]),

--- a/apps/nuxt-regle/vitest.config.ts
+++ b/apps/nuxt-regle/vitest.config.ts
@@ -24,5 +24,15 @@ export default defineVitestConfig({
         "**/dist/**",
       ],
     },
+    onConsoleLog(log) {
+      // Suppress known warnings that can't be fixed at the moment
+      if (
+        log.includes("<Suspense> is an experimental feature") ||
+        log.includes('injection "Symbol(regle)" not found') ||
+        log.includes("Regle Devtools are not available")
+      ) {
+        return false;
+      }
+    },
   },
 });

--- a/apps/nuxt/layers/base/app/components/ui/dialog/__tests__/Dialog.test.ts
+++ b/apps/nuxt/layers/base/app/components/ui/dialog/__tests__/Dialog.test.ts
@@ -9,6 +9,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogFooter,
 } from '../index'
 import { useDisclosure } from "~base/app/composables/useDisclosure"
@@ -50,7 +51,10 @@ const TestDialog = defineComponent({
               {
                 default: () => [
                   h(DialogHeader, {}, {
-                    default: () => h(DialogTitle, {}, { default: () => titleText }),
+                    default: () => [
+                      h(DialogTitle, {}, { default: () => titleText }),
+                      h(DialogDescription, { class: 'sr-only' }, { default: () => 'Dialog description' }),
+                    ],
                   }),
                   h(DialogFooter, {}, {
                     default: () => [

--- a/apps/nuxt/layers/base/app/components/ui/drawer/__tests__/Drawer.test.ts
+++ b/apps/nuxt/layers/base/app/components/ui/drawer/__tests__/Drawer.test.ts
@@ -9,6 +9,7 @@ import {
   DrawerContent,
   DrawerHeader,
   DrawerTitle,
+  DrawerDescription,
   DrawerFooter,
 } from '../index'
 import { useDisclosure } from "~base/app/composables/useDisclosure"
@@ -53,7 +54,10 @@ const TestDrawer = defineComponent({
                 default: () => [
                   h('div', { class: 'flex flex-col' }, [
                     h(DrawerHeader, {}, {
-                      default: () => h(DrawerTitle, {}, { default: () => titleText }),
+                      default: () => [
+                        h(DrawerTitle, {}, { default: () => titleText }),
+                        h(DrawerDescription, { class: 'sr-only' }, { default: () => 'Drawer description' }),
+                      ],
                     }),
                     h('div', {}, drawerContentText),
                   ]),

--- a/apps/nuxt/vitest.config.ts
+++ b/apps/nuxt/vitest.config.ts
@@ -24,5 +24,11 @@ export default defineVitestConfig({
         "**/dist/**",
       ],
     },
+    onConsoleLog(log) {
+      // Suppress known warnings that can't be fixed at the moment
+      if (log.includes("<Suspense> is an experimental feature")) {
+        return false;
+      }
+    },
   },
 });


### PR DESCRIPTION
- Add onConsoleLog filter to suppress Vue Suspense experimental warning
- Add DialogDescription to Dialog tests for accessibility compliance
- Add DrawerDescription to Drawer tests for accessibility compliance
- Suppress Regle-specific warnings in nuxt-regle app