### PR TITLE
fix(nuxt-formwerk): add cleanup to Form tests to prevent unhandled rejections

### DIFF
--- a/apps/nuxt-formwerk/layers/base/app/components/ui/__tests__/Form.test.ts
+++ b/apps/nuxt-formwerk/layers/base/app/components/ui/__tests__/Form.test.ts
@@ -1,10 +1,17 @@
-import { expect, test, vi } from "vitest";
+import { afterEach, expect, test, vi } from "vitest";
 import { defineComponent, h } from "vue";
 import { z } from "zod";
 import Form from "../Form.vue";
 import Input from "../Input.vue";
 import Button from "../Button.vue";
-import { renderComponent, screen, userEvent, waitFor } from "~~/test/test-utils";
+import { cleanup, renderComponent, screen, userEvent, waitFor } from "~~/test/test-utils";
+
+// Clean up after each test and wait for pending operations
+afterEach(async () => {
+  cleanup();
+  // Wait for any pending async operations from formwerk
+  await new Promise(resolve => setTimeout(resolve, 100));
+});
 
 const testData = {
   title: "Hello World",


### PR DESCRIPTION
## Summary
- Add `afterEach` hook to Form.test.ts to properly clean up after each test
- Wait for pending async operations from @formwerk/core to complete

## Problem
@formwerk/core@0.14.4 runs validation in `setTimeout` callbacks. When tests complete, these callbacks may still be pending and try to access `document`, causing "ReferenceError: document is not defined" errors.

## Solution
Added cleanup that:
1. Calls `cleanup()` to unmount components
2. Waits 100ms for pending formwerk async operations to complete

## Test plan
- [x] All 22 unit tests pass locally
- [x] No "Unhandled Errors" in test output