### PR TITLE
fix(ci): add minimumReleaseAge and OSV alerts to Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,11 +3,15 @@
   "extends": [
     "config:recommended"
   ],
+  "internalChecksFilter": "strict",
+  "prCreation": "not-pending",
+  "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
-      "description": "Auto-merge patch and minor updates",
+      "description": "Auto-merge patch and minor updates after 3 days",
       "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true
+      "automerge": true,
+      "minimumReleaseAge": "3 days"
     },
     {
       "description": "Keep zod v3 for bulletproof-nuxt (VeeValidate compatibility)",


### PR DESCRIPTION
- Add minimumReleaseAge of 3 days to cover npm unpublish window
- Suppress PR creation until release age passes (prCreation: not-pending)
- Enable strict internal checks filter
- Enable osvVulnerabilityAlerts to block updates to vulnerable versions